### PR TITLE
kernel_build: Support kernel v6.1.74 compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN dnf -y update && \
         make \
         flex \
         bison \
+        openssl \
         openssl-devel \
+        openssl-devel-engine \
         elfutils-libelf-devel \
 	elfutils-devel \
         wget \


### PR DESCRIPTION
For kvmCTF:
https://github.com/google/security-research/blob/master/kvmctf/rules.md The server currently used has kernel v6.1.74.
This program is for VM-reachable Kernel-based Virtual Machine (KVM) vulnerabilities.